### PR TITLE
Use RetroArch's system directory for Kickstart/BIOS files

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -15,6 +15,16 @@ GEN      = $(CORE_DIR)/sources/gen
 INCFLAGS := -I$(EMU) -I$(EMU)/include -I$(LIBRETRO) -I$(CORE_DIR)/libretro-include -I$(LIBUTILS) -I$(ODFS) -I$(ODFS)/include -I$(EMU)/../softfloat -I$(CORE_DIR) -I$(LIBFSEMU)/../include
 
 SOURCES_C =
+
+SOURCES_C += $(LIBRETRO)/libretro.c \
+				 $(CORE_DIR)/libco/libco.c \
+				 $(LIBRETRO)/libretro-mapper.c \
+				 $(LIBRETRO)/vkbd.c \
+				 $(LIBRETRO)/graph.c \
+				 $(LIBRETRO)/diskutils.c \
+				 $(LIBRETRO)/fontmsx.c 
+
+
 SOURCES_C +=  $(EMU)/main.c \
 				  $(EMU)/newcpu.c \
 				  $(EMU)/newcpu_common.c \
@@ -230,15 +240,6 @@ SOURCES_C += $(GUI)/dialog.c\
 				 $(GUI)/dlgRom.c \
 				 $(GUI)/dlgSystem.c \
 				 $(GUI)/sdlgui.c
-
-SOURCES_C += $(LIBRETRO)/libretro.c \
-				 $(CORE_DIR)/libco/libco.c \
-				 $(LIBRETRO)/libretro-mapper.c \
-				 $(LIBRETRO)/vkbd.c \
-				 $(LIBRETRO)/graph.c \
-				 $(LIBRETRO)/diskutils.c \
-				 $(LIBRETRO)/fontmsx.c 
-
 
 CFLAGS += -DUAE -DLIBRETRO_FSUAE -DUSE_GLIB -DUSE_PSEM
 

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -53,7 +53,7 @@ extern void update_input(void);
 static retro_video_refresh_t video_cb;
 static retro_audio_sample_t audio_cb;
 static retro_audio_sample_batch_t audio_batch_cb;
-static retro_environment_t environ_cb;
+retro_environment_t environ_cb;
 
 static struct retro_input_descriptor input_descriptors[] = {
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP, "Up" },

--- a/sources/src/fs-uae/paths.c
+++ b/sources/src/fs-uae/paths.c
@@ -249,8 +249,7 @@ const char *fs_uae_kickstarts_dir()
 {
     static const char *path;
     if (!path) {
-        path = create_default_dir("Kickstarts", "kickstarts_dir", "roms_dir",
-                "kickstarts-dir");
+        environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &path);
     }
     return path;
 }

--- a/sources/src/fs-uae/paths.h
+++ b/sources/src/fs-uae/paths.h
@@ -1,3 +1,5 @@
+#include "libretro.h"
+
 const char* fs_uae_base_dir(void);
 const char *fs_uae_plugins_dir(void);
 const char *fs_uae_data_dir(void);
@@ -12,3 +14,4 @@ struct multipath {
 };
 
 extern struct multipath g_paths[5];
+extern retro_environment_t environ_cb;


### PR DESCRIPTION
To match the setup of other libretro modules, use the RA system folder for BIOS files rather than FS-UAE's default "Documents/FS-UAE/Kickstarts" folder.
